### PR TITLE
Fixes for paths and URLs

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -1,6 +1,7 @@
 <?php namespace NSRosenqvist\AssetRevisions;
 
 use Cms\Classes\Theme;
+use Cms\Classes\Controller;
 use File;
 use Config;
 use Request;
@@ -42,10 +43,9 @@ class Plugin extends \System\Classes\PluginBase
     {
         if (isset(self::$lookup[$text]))
         {
-            return Request::root().'/'.$this->getThemeDir().'/'.self::$lookup[$text];
+            return Controller::getController()->themeUrl(self::$lookup[$text]);
         }
-
-        return Request::root().'/'.$this->getThemeDir().'/'.$text;
+        return Controller::getController()->themeUrl($text);
     }
 
     protected function loadLookup()
@@ -72,6 +72,6 @@ class Plugin extends \System\Classes\PluginBase
         if (is_null(self::$theme))
             self::$theme = Theme::getActiveTheme();
 
-        return ltrim(Config::get('cms.themesPath'),'/').'/'.self::$theme->getDirName();
+        return base_path().ltrim(Config::get('cms.themesPath'),'/').'/'.self::$theme->getDirName();
     }
 }


### PR DESCRIPTION
Hi,

Thank you for this plugin. I ran into a couple small issues when using:

1. The URL generated by the |revision filter wasn't matching what would get generated by the |theme filter. For me this had to do with HTTP/HTTPS.

To address, I am using the October Controller's `themeUrl` method (replacing the `Request::root()` use).

2. In the `getThemeDir` method, it was generating a relative path, and the plugin wasn't finding the manifest file. I am using `base_path()` to get an absolute path to the theme.

Thank you!